### PR TITLE
Prevent creating connections on a disposed object

### DIFF
--- a/src/SharpRabbit/RabbitConnection.cs
+++ b/src/SharpRabbit/RabbitConnection.cs
@@ -39,6 +39,9 @@ namespace SharpRabbit
 
         public bool TryConnect()
         {
+            if (_disposed)
+                throw new ObjectDisposedException(GetType().FullName);
+
             if (IsConnected)
                 return true;
 

--- a/tests/SharpRabbit.Tests/RabbitConnection/DisposeTests.cs
+++ b/tests/SharpRabbit.Tests/RabbitConnection/DisposeTests.cs
@@ -58,5 +58,38 @@ namespace SharpRabbit.Tests.RabbitConnection
 
             connectionMock.Verify(c => c.Dispose(), Times.Once);
         }
+
+        /*
+        // When CreateModel is called on a disposed rabbitConnection object, it throws a
+        // BrokerUnreachableException but still creates a connection.
+        // This is because IsConnected returns false only because _disposed is true,
+        // while _connection?.IsOpen is also true.
+        [Fact]
+        public void CreatedModelCalled_OnDisposedConnection_CreatesConnections()
+        {
+            var connectionFactoryMock = new Mock<IConnectionFactory>();
+            var connectionMock = new Mock<IConnection>();
+
+            connectionFactoryMock
+                .Setup(c => c.CreateConnection())
+                .Returns(connectionMock.Object);
+
+            var rabbitConnection = new SharpRabbit.RabbitConnection(
+                    _logger,
+                    connectionFactoryMock.Object);
+
+            rabbitConnection.TryConnect();
+
+            rabbitConnection.Dispose();
+            connectionMock.Verify(c => c.Dispose(), Times.Once);
+
+            // Create channel on disposed connection
+            var exception = Record.Exception(() => rabbitConnection.CreateModel());
+            Assert.IsType<BrokerUnreachableException>(exception);
+
+            // CreateConnection was called again and a connection was created.
+            connectionFactoryMock.Verify(c => c.CreateConnection(), Times.Exactly(2));
+        }
+        */
     }
 }


### PR DESCRIPTION
When CreateModel is called on a disposed rabbitConnection object, it throws a BrokerUnreachableException but still creates a connection. This is because IsConnected returns false only because _disposed is true, while _connection?.IsOpen is also true.